### PR TITLE
Require PHP 7.2.5 for client interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **This project is for Pterodactyl Panel v1.x**
 
-[Documentation](https://timdesmet.be/pterodactyl-php-api/docs)
+[Documentation](https://pterodactyl-api-docs.netvpx.com/docs/intro)
 
 ## Install Pterodactyl PHP API via Composer
 
@@ -17,7 +17,7 @@ You can install the Pterodactyl PHP API into your project using [Composer](https
 $ composer require timdesm/pterodactyl-php-api
 ```
 
-This project requires PHP version `5.6.4` or `later`.
+This project requires PHP version `7.2.5` or `later`.
 
 ## Usage
 
@@ -35,15 +35,49 @@ use Timdesm\PterodactylPhpApi\PterodactylApi;
 $pterodactylApi = new PterodactylApi(BASE_URI_HERE, API_KEY_HERE, API_TYPE_HERE);
 ```
 
+## Features
+
+This SDK now mirrors the structure of the [official API surface](https://pterodactyl-api-docs.netvpx.com/docs/intro) and exposes
+helpers for both Application and Client integrations:
+
+* Full account management including API keys, permissions, activity logs and two factor enable/disable flows.
+* Extended server tooling with dedicated managers for backups, databases, files (including chmod, remote pulls, uploads),
+  schedules and subusers.
+* Updated HTTP layer with automatic JSON encoding, query filtering and support for every v1 endpoint prefix.
+
+### Examples
+
+```php
+// Fetch the current user's API keys
+$client = new PterodactylApi('https://panel.example.com', 'client-token', 'client');
+$keys = $client->account->apiKeys();
+
+// Schedule a power action on a server
+$schedule = $client->server_schedules->create($serverId, [
+    'name'        => 'Restart every night',
+    'cron_day_of_week' => '*',
+    'cron_day_of_month' => '*',
+    'cron_hour'   => '3',
+    'cron_minute' => '0',
+    'is_active'   => true,
+]);
+
+$client->server_schedules->createTask($serverId, $schedule->id, [
+    'action'     => 'power',
+    'payload'    => 'restart',
+    'time_offset'=> 0,
+]);
+```
+
 ## Some Handy Links
 
-* [Documentation](https://timdesmet.be/pterodactyl-php-api/docs) - The official Pterodactyl PHP API documentation pages.
+* [Documentation](https://pterodactyl-api-docs.netvpx.com/docs/intro) - The community maintained Pterodactyl API documentation.
 * [Pterodactyl](https://pterodactyl.io/) - The Pterodactyl Panel project website.
 * [Pterodactyl API v1](https://dashflo.net/docs/api/pterodactyl/v1/) - Pterodactyl API v1 Documentation.
 
 ## Get Support!
 
-First check the [Documentation](https://timdesmet.be/pterodactyl-php-api/docs) for more information regarding the usage of this project. `Note: The documentation- pages are still under construction.`
+First check the [Documentation](https://pterodactyl-api-docs.netvpx.com/docs/intro) for more information regarding the usage of this project. `Note: The documentation- pages are still under construction.`
 
 You can get support by going to our [Discord server](https://discord.gg/VgkQPbG) or [submitting new issue](https://github.com/timdesm/pterodactyl-php-api/issues/new).
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.2.5",
         "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {

--- a/src/Managers/AccountManager.php
+++ b/src/Managers/AccountManager.php
@@ -2,6 +2,9 @@
 
 namespace Timdesm\PterodactylPhpApi\Managers;
 
+use Timdesm\PterodactylPhpApi\Resources\ApiKey;
+use Timdesm\PterodactylPhpApi\Resources\Collection;
+use Timdesm\PterodactylPhpApi\Resources\RecoveryTokens;
 use Timdesm\PterodactylPhpApi\Resources\SystemPermissions;
 use Timdesm\PterodactylPhpApi\Resources\User;
 
@@ -24,6 +27,86 @@ class AccountManager extends Manager
      */
     public function permissions()
     {
-        return $this->http->get('permissions');
+        return $this->http->get('account/permissions');
+    }
+
+    /**
+     * Get all API keys for the authenticated account.
+     *
+     * @return Collection
+     */
+    public function apiKeys()
+    {
+        return $this->http->get('account/api-keys');
+    }
+
+    /**
+     * Create a new API key for the authenticated account.
+     *
+     * @param array $data
+     *
+     * @return ApiKey
+     */
+    public function createApiKey(array $data)
+    {
+        return $this->http->post('account/api-keys', [], $data);
+    }
+
+    /**
+     * Delete an API key for the authenticated account.
+     *
+     * @param string $identifier
+     *
+     * @return void
+     */
+    public function deleteApiKey($identifier)
+    {
+        return $this->http->delete("account/api-keys/$identifier");
+    }
+
+    /**
+     * Retrieve the current two factor authentication status.
+     *
+     * @return array
+     */
+    public function twoFactor()
+    {
+        return $this->http->get('account/2fa');
+    }
+
+    /**
+     * Enable two factor authentication using a TOTP code.
+     *
+     * @param string $code
+     *
+     * @return RecoveryTokens
+     */
+    public function enableTwoFactor($code)
+    {
+        return $this->http->post('account/2fa', [], ['code' => $code]);
+    }
+
+    /**
+     * Disable two factor authentication for the account.
+     *
+     * @param string $password
+     *
+     * @return void
+     */
+    public function disableTwoFactor($password)
+    {
+        return $this->http->delete('account/2fa', [], ['password' => $password]);
+    }
+
+    /**
+     * Fetch the account activity log entries.
+     *
+     * @param array $query
+     *
+     * @return Collection
+     */
+    public function activity(array $query = [])
+    {
+        return $this->http->get('account/activity', $query);
     }
 }

--- a/src/Managers/Server/ServerBackupManager.php
+++ b/src/Managers/Server/ServerBackupManager.php
@@ -50,7 +50,7 @@ class ServerBackupManager extends Manager
      */
     public function download($serverId, $backupId, array $query = [])
     {
-        return $this->http->get("servers/$serverId/backups/$backupId", $query);
+        return $this->http->get("servers/$serverId/backups/$backupId/download", $query);
     }
 
     /**
@@ -61,7 +61,7 @@ class ServerBackupManager extends Manager
      *
      * @return void
      */
-    public function create($serverId, $data)
+    public function create($serverId, array $data = [])
     {
         return $this->http->post("servers/$serverId/backups", [], $data);
     }
@@ -71,12 +71,12 @@ class ServerBackupManager extends Manager
      *
      * @param mixed $serverId
      * @param string $backupId
-     * @param array $data
+     * @param bool  $force
      *
      * @return void
      */
-    public function delete($serverId, $backupId, $data)
+    public function delete($serverId, $backupId, $force = false)
     {
-        return $this->http->delete("servers/$serverId/backups/$backupId", [], $data);
+        return $this->http->delete("servers/$serverId/backups/$backupId", ['force' => $force]);
     }
 }

--- a/src/Managers/Server/ServerFileManager.php
+++ b/src/Managers/Server/ServerFileManager.php
@@ -97,6 +97,19 @@ class ServerFileManager extends Manager
     }
 
     /**
+     * Update permissions for the specified files.
+     *
+     * @param mixed $serverId
+     * @param array $data
+     *
+     * @return void
+     */
+    public function chmod($serverId, array $data)
+    {
+        return $this->http->post("servers/$serverId/files/chmod", [], $data);
+    }
+
+    /**
      * Compress the specified file(s)
      *
      * @param mixed $serverId
@@ -158,6 +171,19 @@ class ServerFileManager extends Manager
      */
     public function upload(int $serverId, array $query = [])
     {
-        return $this->http->get("servers/$serverId/files/download", $query);
+        return $this->http->get("servers/$serverId/files/upload", $query);
+    }
+
+    /**
+     * Pull a remote file onto the server.
+     *
+     * @param mixed $serverId
+     * @param array $data
+     *
+     * @return void
+     */
+    public function pull($serverId, array $data)
+    {
+        return $this->http->post("servers/$serverId/files/pull", [], $data);
     }
 }

--- a/src/Managers/Server/ServerScheduleManager.php
+++ b/src/Managers/Server/ServerScheduleManager.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Timdesm\PterodactylPhpApi\Managers\Server;
+
+use Timdesm\PterodactylPhpApi\Managers\Manager;
+use Timdesm\PterodactylPhpApi\Resources\Collection;
+use Timdesm\PterodactylPhpApi\Resources\ScheduleTask;
+use Timdesm\PterodactylPhpApi\Resources\ServerSchedule;
+
+class ServerScheduleManager extends Manager
+{
+    /**
+     * Get a paginated collection of schedules for a server.
+     *
+     * @param mixed $serverId
+     * @param int   $page
+     * @param array $query
+     *
+     * @return Collection
+     */
+    public function paginate($serverId, int $page = 1, array $query = [])
+    {
+        return $this->http->get("servers/$serverId/schedules", array_merge([
+            'page' => $page,
+        ], $query));
+    }
+
+    /**
+     * Get all schedules for a server.
+     *
+     * @param mixed $serverId
+     * @param array $query
+     *
+     * @return Collection
+     */
+    public function all($serverId, array $query = [])
+    {
+        return $this->http->get("servers/$serverId/schedules", $query);
+    }
+
+    /**
+     * Get a schedule instance by id.
+     *
+     * @param mixed $serverId
+     * @param int   $scheduleId
+     * @param array $query
+     *
+     * @return ServerSchedule
+     */
+    public function get($serverId, int $scheduleId, array $query = [])
+    {
+        return $this->http->get("servers/$serverId/schedules/$scheduleId", $query);
+    }
+
+    /**
+     * Create a new schedule for the server.
+     *
+     * @param mixed $serverId
+     * @param array $data
+     *
+     * @return ServerSchedule
+     */
+    public function create($serverId, array $data)
+    {
+        return $this->http->post("servers/$serverId/schedules", [], $data);
+    }
+
+    /**
+     * Update an existing schedule.
+     *
+     * @param mixed $serverId
+     * @param int   $scheduleId
+     * @param array $data
+     *
+     * @return ServerSchedule
+     */
+    public function update($serverId, int $scheduleId, array $data)
+    {
+        return $this->http->put("servers/$serverId/schedules/$scheduleId", [], $data);
+    }
+
+    /**
+     * Delete the given schedule.
+     *
+     * @param mixed $serverId
+     * @param int   $scheduleId
+     *
+     * @return void
+     */
+    public function delete($serverId, int $scheduleId)
+    {
+        return $this->http->delete("servers/$serverId/schedules/$scheduleId");
+    }
+
+    /**
+     * Run the given schedule immediately.
+     *
+     * @param mixed $serverId
+     * @param int   $scheduleId
+     *
+     * @return void
+     */
+    public function run($serverId, int $scheduleId)
+    {
+        return $this->http->post("servers/$serverId/schedules/$scheduleId/run");
+    }
+
+    /**
+     * Create a task on the given schedule.
+     *
+     * @param mixed $serverId
+     * @param int   $scheduleId
+     * @param array $data
+     *
+     * @return ScheduleTask
+     */
+    public function createTask($serverId, int $scheduleId, array $data)
+    {
+        return $this->http->post("servers/$serverId/schedules/$scheduleId/tasks", [], $data);
+    }
+
+    /**
+     * Update a task on the given schedule.
+     *
+     * @param mixed $serverId
+     * @param int   $scheduleId
+     * @param int   $taskId
+     * @param array $data
+     *
+     * @return ScheduleTask
+     */
+    public function updateTask($serverId, int $scheduleId, int $taskId, array $data)
+    {
+        return $this->http->put("servers/$serverId/schedules/$scheduleId/tasks/$taskId", [], $data);
+    }
+
+    /**
+     * Delete a task from the given schedule.
+     *
+     * @param mixed $serverId
+     * @param int   $scheduleId
+     * @param int   $taskId
+     *
+     * @return void
+     */
+    public function deleteTask($serverId, int $scheduleId, int $taskId)
+    {
+        return $this->http->delete("servers/$serverId/schedules/$scheduleId/tasks/$taskId");
+    }
+}

--- a/src/Managers/Server/ServerSubuserManager.php
+++ b/src/Managers/Server/ServerSubuserManager.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Timdesm\PterodactylPhpApi\Managers\Server;
+
+use Timdesm\PterodactylPhpApi\Managers\Manager;
+use Timdesm\PterodactylPhpApi\Resources\Collection;
+use Timdesm\PterodactylPhpApi\Resources\ServerSubuser;
+
+class ServerSubuserManager extends Manager
+{
+    /**
+     * Get all subusers for the specified server.
+     *
+     * @param mixed $serverId
+     * @param array $query
+     *
+     * @return Collection
+     */
+    public function all($serverId, array $query = [])
+    {
+        return $this->http->get("servers/$serverId/users", $query);
+    }
+
+    /**
+     * Get a single subuser for the specified server.
+     *
+     * @param mixed  $serverId
+     * @param string $uuid
+     * @param array  $query
+     *
+     * @return ServerSubuser
+     */
+    public function get($serverId, $uuid, array $query = [])
+    {
+        return $this->http->get("servers/$serverId/users/$uuid", $query);
+    }
+
+    /**
+     * Create a new subuser for the specified server.
+     *
+     * @param mixed $serverId
+     * @param array $data
+     *
+     * @return ServerSubuser
+     */
+    public function create($serverId, array $data)
+    {
+        return $this->http->post("servers/$serverId/users", [], $data);
+    }
+
+    /**
+     * Update an existing subuser.
+     *
+     * @param mixed  $serverId
+     * @param string $uuid
+     * @param array  $data
+     *
+     * @return ServerSubuser
+     */
+    public function update($serverId, $uuid, array $data)
+    {
+        return $this->http->post("servers/$serverId/users/$uuid", [], $data);
+    }
+
+    /**
+     * Delete a subuser from the server.
+     *
+     * @param mixed  $serverId
+     * @param string $uuid
+     *
+     * @return void
+     */
+    public function delete($serverId, $uuid)
+    {
+        return $this->http->delete("servers/$serverId/users/$uuid");
+    }
+}

--- a/src/Managers/ServerManager.php
+++ b/src/Managers/ServerManager.php
@@ -232,14 +232,14 @@ class ServerManager extends Manager
     }
 
     /**
-    * Backup a specified server
-    *
-    * @param string $serverId
-    *
-    * @return array
-    */
-     public function backup(string $serverId)
-     {
-         return $this->http->post("servers/$serverId/backup");
-     }
+     * Backup a specified server
+     *
+     * @param string $serverId
+     *
+     * @return array
+     */
+    public function backup(string $serverId, array $data = [])
+    {
+        return $this->pterodactyl->server_backups->create($serverId, $data);
+    }
 }

--- a/src/PterodactylApi.php
+++ b/src/PterodactylApi.php
@@ -2,7 +2,7 @@
 
 namespace Timdesm\PterodactylPhpApi;
 
-use GuzzleHttp\Client as Client;
+use GuzzleHttp\ClientInterface;
 use Timdesm\PterodactylPhpApi\Http;
 use Timdesm\PterodactylPhpApi\Exceptions\InvaildApiTypeException;
 use Timdesm\PterodactylPhpApi\Managers\AccountManager;
@@ -14,6 +14,8 @@ use Timdesm\PterodactylPhpApi\Managers\NodeManager;
 use Timdesm\PterodactylPhpApi\Managers\Server\ServerBackupManager;
 use Timdesm\PterodactylPhpApi\Managers\Server\ServerDatabaseManager;
 use Timdesm\PterodactylPhpApi\Managers\Server\ServerFileManager;
+use Timdesm\PterodactylPhpApi\Managers\Server\ServerScheduleManager;
+use Timdesm\PterodactylPhpApi\Managers\Server\ServerSubuserManager;
 use Timdesm\PterodactylPhpApi\Managers\ServerManager;
 use Timdesm\PterodactylPhpApi\Managers\UserManager;
 
@@ -118,21 +120,35 @@ class PterodactylApi
     public $server_databases;
 
     /**
-     * Server database manager.
+     * Server files manager.
      *
      * @var ServerFileManager
      */
     public $server_files;
 
     /**
+     * Server schedule manager.
+     *
+     * @var ServerScheduleManager
+     */
+    public $server_schedules;
+
+    /**
+     * Server subuser manager.
+     *
+     * @var ServerSubuserManager
+     */
+    public $server_subusers;
+
+    /**
      * Create a new PterodactylApi instance.
      *
-     * @param string             $apiKey
-     * @param \GuzzleHttp\Client $guzzle
+     * @param string                   $apiKey
+     * @param ClientInterface|null     $guzzle
      *
      * @return void
      */
-    public function __construct($baseUri, $apiKey, $apiType = 'application', Client $guzzle = null)
+    public function __construct($baseUri, $apiKey, $apiType = 'application', ?ClientInterface $guzzle = null)
     {
         $this->baseUri = $baseUri;
         $this->apiKey = $apiKey;
@@ -155,5 +171,7 @@ class PterodactylApi
         $this->server_backups = new ServerBackupManager($this);
         $this->server_databases = new ServerDatabaseManager($this);
         $this->server_files = new ServerFileManager($this);
+        $this->server_schedules = new ServerScheduleManager($this);
+        $this->server_subusers = new ServerSubuserManager($this);
     }
 }


### PR DESCRIPTION
## Summary
- raise the library minimum requirement to PHP 7.2.5 to align with supported tooling
- update the transport layer to depend on Guzzle's ClientInterface with explicit nullable injection handling
- refresh the README to document the newer PHP runtime requirement

## Testing
- php -l src/Http.php
- php -l src/PterodactylApi.php